### PR TITLE
prefix record target to not collide with other targets

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,11 +2,12 @@ add_executable(print print.cpp)
 add_dependencies(print razer_hydra)
 target_link_libraries(print razer_hydra ${catkin_LIBRARIES})
 
-add_executable(record record.cpp)
-add_dependencies(record razer_hydra)
-target_link_libraries(record razer_hydra ${catkin_LIBRARIES})
+add_executable(${PROJECT_NAME}_record record.cpp)
+add_dependencies(${PROJECT_NAME}_record razer_hydra)
+target_link_libraries(${PROJECT_NAME}_record razer_hydra ${catkin_LIBRARIES})
+set_target_properties(${PROJECT_NAME}_record PROPERTIES OUTPUT_NAME record)
 
-install(TARGETS print record
+install(TARGETS print ${PROJECT_NAME}_record
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
Please release fixed version into Hydro since this currently blocks building all Hydro packages in a single workspace.
