### PR TITLE
Use "Public Domain" license for razer_hydra

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <description>Unofficial driver and ROS node for Razer Hydra</description>
   <maintainer email="adamleeper@gmail.com">Adam Leeper</maintainer>
 
-  <license></license>
+  <license>Public Domain</license>
 
   <url type="website">http://www.ros.org/wiki/razer_hydra</url>
   <url type="bugtracker">https://github.com/aleeper/razer_hydra/issues</url>


### PR DESCRIPTION
Source files in the project state that the code is Public Domain

Please do not use an empty license tag.

See: https://github.com/ros-infrastructure/bloom/pull/250
