### PR TITLE
Use "Public Domain" license for razer_hydra

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <description>Unofficial driver and ROS node for Razer Hydra</description>
   <maintainer email="adamleeper@gmail.com">Adam Leeper</maintainer>
 
-  <license></license>
+  <license>Public Domain</license>
 
   <url type="website">http://www.ros.org/wiki/razer_hydra</url>
   <url type="bugtracker">https://github.com/aleeper/razer_hydra/issues</url>


### PR DESCRIPTION
It is against packaging spec to not have a license. I see that your code indicates public domain, so please indicate so in the `package.xml`.

Thanks!
